### PR TITLE
Accept `...` as frontmatter terminator (pandoc syntax)

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -93,23 +93,23 @@ func NewParser() parser.BlockParser {
 }
 
 func isStartSeparator(line []byte) bool {
-	line = util.TrimRightSpace(util.TrimLeftSpace(line))
+	line = util.TrimRightSpace(line)
 	for i := 0; i < len(line); i++ {
 		if line[i] != '-' {
 			return false
 		}
 	}
-	return true
+	return len(line) >= 3
 }
 
 func isEndSeparator(line []byte) bool {
-	line = util.TrimRightSpace(util.TrimLeftSpace(line))
+	line = util.TrimRightSpace(line)
 	for i := 0; i < len(line); i++ {
 		if line[i] != '-' && line[i] != '.' {
 			return false
 		}
 	}
-	return true
+	return len(line) >= 3
 }
 
 func (b *metaParser) Trigger() []byte {

--- a/meta.go
+++ b/meta.go
@@ -92,10 +92,20 @@ func NewParser() parser.BlockParser {
 	return defaultParser
 }
 
-func isSeparator(line []byte) bool {
+func isStartSeparator(line []byte) bool {
 	line = util.TrimRightSpace(util.TrimLeftSpace(line))
 	for i := 0; i < len(line); i++ {
 		if line[i] != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func isEndSeparator(line []byte) bool {
+	line = util.TrimRightSpace(util.TrimLeftSpace(line))
+	for i := 0; i < len(line); i++ {
+		if line[i] != '-' && line[i] != '.' {
 			return false
 		}
 	}
@@ -112,7 +122,7 @@ func (b *metaParser) Open(parent gast.Node, reader text.Reader, pc parser.Contex
 		return nil, parser.NoChildren
 	}
 	line, _ := reader.PeekLine()
-	if isSeparator(line) {
+	if isStartSeparator(line) {
 		return gast.NewTextBlock(), parser.NoChildren
 	}
 	return nil, parser.NoChildren
@@ -120,7 +130,7 @@ func (b *metaParser) Open(parent gast.Node, reader text.Reader, pc parser.Contex
 
 func (b *metaParser) Continue(node gast.Node, reader text.Reader, pc parser.Context) parser.State {
 	line, segment := reader.PeekLine()
-	if isSeparator(line) && !util.IsBlank(line) {
+	if isEndSeparator(line) && !util.IsBlank(line) {
 		reader.Advance(segment.Len())
 		return parser.Close
 	}


### PR DESCRIPTION
Pandoc for some reason [accepts `...`](https://pandoc.org/MANUAL.html#extension-yaml_metadata_block) as a yaml frontmatter separator, and people [actually use this](https://github.com/go-gitea/gitea/issues/19061#issuecomment-1066706357).